### PR TITLE
update eula param to accept_eula for all files

### DIFF
--- a/lib/puppet/type/xcode.rb
+++ b/lib/puppet/type/xcode.rb
@@ -21,7 +21,7 @@ Puppet::Type.newtype(:xcode) do
     desc 'Override the default value of /Application/Xcode-v{version}.app'
   end
 
-  newparam(:eula) do
+  newparam(:accept_eula) do
     desc 'What should we do about the EULA for Xcode'
     newvalues(:accept, :ignore, :no)
     defaultto 'ignore'

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -46,7 +46,7 @@
 define xcode::instance(
   $source_url,
   $ensure = present,
-  $accept = 'ignore',
+  $accept_eula = 'ignore',
   $cache_installer = $::xcode::cache_installers,
   $timeout = $::xcode::timeout
   ) {


### PR DESCRIPTION
The eula parameter was incorrect, which was causing the puppet runs to skip on the macs.