### PR TITLE
Puppet 4 Compatibility - new parameter for xcode-select - couple of fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,36 @@ include xcode
 xcode::instance {
     'Xcode v7.1.1':
         ensure      => present,
-        source_url  => 'http://cache.mydomain.com/xcode/Xcode_7.1.1.dmg';
+        source_url  => 'http://cache.mydomain.com/xcode/Xcode_7.1.1.dmg',
 }
 ```
 
 By default, this module will *not* accept the EULA for Xcode. However, if you pass in the parameter 'eula' as 'accept', we will accept the EULA for Xcode requiring no manual intervention.
 
 If the value of 'eula' is not 'accept', then the EULA will be left as is.
+
+```
+include xcode
+
+xcode::instance {
+  'Xcode v7.1.1':
+    ensure      => present,
+    source_url  => 'http://cache.mydomain.com/xcode/Xcode_7.1.1.dmg',
+    eula        => 'accept',
+}
+```
+
+By default, this module will 'xcode-select' the newly installed Xcode. If you do not want this to happen set the parameter 'selected' to 'no'.
+
+```
+include xcode
+
+xcode::instance {
+  'Xcode v7.1.1':
+    ensure      => present,
+    source_url  => 'http://cache.mydomain.com/xcode/Xcode_7.1.1.dmg',
+    selected    => 'no',
+}
 
 ## Reference
 

--- a/lib/puppet/type/xcode.rb
+++ b/lib/puppet/type/xcode.rb
@@ -27,6 +27,12 @@ Puppet::Type.newtype(:xcode) do
     defaultto 'ignore'
   end
 
+  newparam(:selected) do
+    desc 'Should we xcode-select this version of XCode'
+    newvalues(:yes, :no)
+    defaultto 'yes'
+  end
+
   ensurable do
     desc 'What state the package should be in'
     defaultto :present
@@ -40,3 +46,4 @@ Puppet::Type.newtype(:xcode) do
     end
   end
 end
+

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -30,6 +30,12 @@
 # [*instances*]
 #   An array of hashes that can be passed into 'xcode::instances'
 #
+# [*eula*]
+#   Automatically accept the EULA
+#
+# [*selected*]
+#   Run 'xcode-select' on the newly installed Xcode
+#
 # === Variables
 #
 # Here you should define a list of variables that this module would require.
@@ -38,7 +44,7 @@
 #
 # class {
 #   '::xcode':
-#     source_url => 'http://intranet.com/squid/xcode';
+#     source_url => 'http://intranet.com/squid/xcode',
 # }
 #
 # === Authors
@@ -56,6 +62,8 @@ class xcode (
   $password = $::xcode::params::password,
   $cache_installers = $::xcode::params::cache_installers,
   $timeout = $::xcode::params::timeout,
+  $eula = $::xcode::params::eula,
+  $selected = $::xcode::params::selected,
   $instances = {}
   ) inherits ::xcode::params {
 

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -29,10 +29,10 @@
 #
 # xcode::instance {
 #   'Xcode 6.1.1':
-#     source_url => 'http://intranet.com/squid/xcode/Xcode_6.1.1.dmg';
+#     source_url => 'http://intranet.com/squid/xcode/Xcode_6.1.1.dmg',
 #
 #   'Xcode 7.2':
-#     source_url => 'http://intranet.com/squid/xcode/Xcode_7.2.dmg';
+#     source_url => 'http://intranet.com/squid/xcode/Xcode_7.2.dmg',
 # }
 #
 # === Authors
@@ -48,7 +48,8 @@ define xcode::instance(
   $ensure = present,
   $eula = 'ignore',
   $cache_installer = $::xcode::cache_installers,
-  $timeout = $::xcode::timeout
+  $timeout = $::xcode::timeout,
+  $selected = 'yes'
   ) {
 
   # The base class must be included first because it is used by parameter defaults
@@ -74,7 +75,7 @@ define xcode::instance(
     if !defined(File['/opt']) {
       file {
         '/opt':
-          ensure => directory;
+          ensure => directory,
       }
     }
 
@@ -85,7 +86,7 @@ define xcode::instance(
           require   => File['/opt'],
           timeout   => $timeout,
           username  => $::xcode::username,
-          password  => $::xcode::password;
+          password  => $::xcode::password,
       }
       $_real_installer = "/opt/staging/xcode/${dmg}"
     }
@@ -98,8 +99,9 @@ define xcode::instance(
 
   xcode {
     $dmg:
-      ensure  => $ensure,
-      source  => $_real_installer,
-      eula    => $eula;
+      ensure   => $ensure,
+      source   => $_real_installer,
+      eula     => $eula,
+      selected => $selected,
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,4 +5,6 @@ class xcode::params {
   $password = undef
   $cache_installers = false
   $timeout = 900
+  $eula = 'ignore'
+  $selected = 'yes'
 }


### PR DESCRIPTION
Enables compatibility with Puppet 4. This is largely achieved by removing
a lot of the plist dependencies which seemed to be in place largel to
handle random mount points. Chose a different way to do this.

Fixed the eula parameter so it actually works.

Added a new parameter 'selected' that defaults to 'yes' which will
'xcode-select' the version of Xcode that is installed. This enables
command line tools which makes life easier.

Updated examples in README.md