### PR TITLE
switched to use xip instead of Archive Utility

### DIFF
--- a/lib/puppet/provider/xcode/ruby.rb
+++ b/lib/puppet/provider/xcode/ruby.rb
@@ -5,7 +5,7 @@ Puppet::Type.type(:xcode).provide(:ruby) do
   commands :hdiutil => '/usr/bin/hdiutil'
   commands :curl    => '/usr/bin/curl'
   commands :ditto   => '/usr/bin/ditto'
-  commands :xiputil => '/System/Library/CoreServices/Applications/Archive Utility.app/Contents/MacOS/Archive Utility'
+  commands :xiputil => '/usr/bin/xip'
 
   MANIFEST_DIR = '/var/db'.freeze
 
@@ -93,7 +93,7 @@ Puppet::Type.type(:xcode).provide(:ruby) do
   end
 
   def self.installxip(source, install_dir)
-    xiputil source
+    xiputil '--expand', source
     extract_dir = File.dirname(source)
 
     if Dir.exist? "#{extract_dir}/Xcode-beta.app"


### PR DESCRIPTION
Fixes #5 
I believe @rcmoutinho's fix proposed in his [issue comment](https://github.com/madelaney/puppet-xcode/issues/5#issuecomment-658270710) is a legitimate fix and not simply a workaround.  This Pull Request is to make it official.

The fix works by trading the Archive Utility for the purpose-built xip utility for extracting Xcode xip archives.